### PR TITLE
Change Maintainer mail address

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: contrib/electronics
 Priority: extra
 Standards-Version: 3.9.8
 Build-Depends: debhelper (>=9), dh-exec
-Maintainer: Kunbus <admin@kunbus.de>
+Maintainer: KUNBUS GmbH <support@kunbus.com>
 Homepage: https://revolution.kunbus.com/
 
 Package: revpi-repo


### PR DESCRIPTION
We rather want to use a mail address as maintainer entry
which is not personalized but valid so that mails will reach
us all.

Signed-off-by: Frank Pavlic <f.pavlic@kunbus.com>