### PR TITLE
Set upstream-branch value in gbp.conf to 2.x

### DIFF
--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,4 +1,5 @@
 [DEFAULT]
+upstream-branch = 2.x
 upstream-tag = v%(version)s
 debian-branch = raspios/buster
 debian-tag = raspios/%(version)s


### PR DESCRIPTION
Version 3.x for Bullseye is now being developed on the master branch. This is no longer compatible with Buster. Changes for Buster will continue to be made available in branch 2.x. Accordingly, the upstream branch for raspios/buster will be switched to the branch 2.x.

> ❗️ I know this is a small package where the 2.x branch is not necessarily needed. But I also see this repository as educational. With this REpository, you could very clearly show colleagues in training how it works when the main branch is no longer compatible with other distributions. That would have helped me to understand everything at the beginning. 😉